### PR TITLE
Upper case acronyms

### DIFF
--- a/examples/actix_example/src/main.rs
+++ b/examples/actix_example/src/main.rs
@@ -3,7 +3,7 @@ mod services;
 use crate::services::{ActixService, Repository};
 use actix_web::{web, App, HttpServer};
 use std::sync::Arc;
-use teloc::{DIActixHandler, ServiceProvider};
+use teloc::{DiActixHandler, ServiceProvider};
 
 async fn index(service: ActixService<'_>, data: String) -> String {
     service.change_and_get_previous(data).await
@@ -30,7 +30,7 @@ async fn main() -> std::io::Result<()> {
             web::post().to(
                 // `DIActixHandler` gives as input a `ServiceProvider` and a handler function and inject
                 // dependencies from the start args in function.
-                DIActixHandler::new(
+                DiActixHandler::new(
                     // Global `ServiceProvider`.
                     sp.clone(),
                     // Scope factory that can add scope instances that will be the same between different

--- a/teloc/src/container.rs
+++ b/teloc/src/container.rs
@@ -25,6 +25,7 @@ pub trait ResolveContainer<'a, Elem, ContGet, Deps> {
     fn resolve_container<F: Fn() -> Deps>(ct: &'a ContGet, get_deps: F) -> Elem;
 }
 
+#[derive(Debug)]
 pub struct TransientContainer<T>(PhantomData<T>);
 impl<T> Init for TransientContainer<T> {
     type Data = ();
@@ -54,6 +55,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct SingletonContainer<T>(OnceCell<T>);
 impl<T> Init for SingletonContainer<T> {
     type Data = ();
@@ -103,6 +105,7 @@ impl<T> SingletonContainer<T> {
     }
 }
 
+#[derive(Debug)]
 pub struct InstanceContainer<T>(T);
 impl<T> Container<T> for InstanceContainer<T> {}
 impl<T> Init for InstanceContainer<T> {
@@ -137,6 +140,7 @@ impl<T> InstanceContainer<T> {
     }
 }
 
+#[derive(Debug)]
 pub struct ByRefSingletonContainer<T>(PhantomData<T>);
 impl<T> Container<&T> for ByRefSingletonContainer<T> {}
 impl<T> Init for ByRefSingletonContainer<T> {
@@ -180,6 +184,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct ByRefInstanceContainer<T>(PhantomData<T>);
 impl<'a, T> Container<&'a T> for ByRefInstanceContainer<T> {}
 impl<T> Init for ByRefInstanceContainer<T> {

--- a/teloc/src/lib.rs
+++ b/teloc/src/lib.rs
@@ -69,7 +69,7 @@ mod service_provider;
 pub mod dev;
 
 #[cfg(feature = "actix-support")]
-pub use actix_support::DIActixHandler;
+pub use actix_support::DiActixHandler;
 
 pub use {
     dependency::Dependency,


### PR DESCRIPTION
Resolves `#[warn(clippy::upper_case_acronyms)]` (on by default) with idiomatic Rust typenames