### PR TITLE
Add inject_init annotation to specify what method to call in `Dependency`

### DIFF
--- a/teloc/tests/inject_init.rs
+++ b/teloc/tests/inject_init.rs
@@ -1,0 +1,27 @@
+use teloc::{inject, Resolver, ServiceProvider};
+
+struct ConstService {
+    number: u8,
+}
+
+#[inject]
+impl ConstService {
+    #[inject::init]
+    pub fn new(number: &u8) -> Self {
+        Self { number: *number }
+    }
+
+    pub fn _ignore(_number: &u8) -> Self {
+        Self { number: 0 }
+    }
+}
+
+#[test]
+fn test() {
+    let provider = ServiceProvider::new()
+        .add_instance(10u8)
+        .add_transient::<ConstService>();
+
+    let service: ConstService = provider.resolve();
+    assert_eq!(service.number, 10u8);
+}

--- a/teloc_macros/Cargo.toml
+++ b/teloc_macros/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 quote = "1.0.7"
 proc-macro2 = "1.0.19"
-syn = { version = "1.0.13",  features = ["full"] }
+syn = { version = "1.0.13",  features = ["full", "extra-traits"] }
 itertools = "0.9.0"
 
 [lib]

--- a/teloc_macros/src/inject.rs
+++ b/teloc_macros/src/inject.rs
@@ -1,5 +1,6 @@
-use crate::common::{compile_error, get_1_method, ident_generator};
+use crate::common::{compile_error, ident_generator};
 use crate::generics::{get_impl_block_generics, get_where_clause};
+use crate::parse::ParseInjectImpl;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::parse::{Parse, ParseBuffer};
@@ -88,9 +89,12 @@ impl Parse for InjectInput {
         if let Ok(f) = input.parse::<ItemFn>() {
             Ok(Self::Function(f))
         } else {
-            let item: ItemImpl = input.parse()?;
-            let assoc = get_1_method(item.clone())?;
-            Ok(Self::Impl(item, assoc))
+            let item_impl: ItemImpl = input.parse()?;
+            let ParseInjectImpl {
+                item_impl,
+                init_method,
+            } = ParseInjectImpl::parse(item_impl)?;
+            Ok(Self::Impl(item_impl, init_method))
         }
     }
 }

--- a/teloc_macros/src/lib.rs
+++ b/teloc_macros/src/lib.rs
@@ -2,6 +2,7 @@ mod common;
 mod derive_teloc;
 mod generics;
 mod inject;
+mod parse;
 
 extern crate proc_macro;
 extern crate quote;

--- a/teloc_macros/src/parse.rs
+++ b/teloc_macros/src/parse.rs
@@ -1,0 +1,86 @@
+use itertools::{Either, Itertools};
+use proc_macro2::Span;
+use syn::spanned::Spanned;
+use syn::{parse_str, ImplItem, ImplItemMethod, ItemImpl, Path};
+
+use crate::common::strip_annotation_by_path;
+
+pub struct ParseInjectImpl {
+    pub item_impl: ItemImpl,
+    pub init_method: ImplItemMethod,
+}
+
+impl ParseInjectImpl {
+    const INIT_ANNOTATION_STR: &'static str = "inject::init";
+
+    pub fn parse(item_impl: ItemImpl) -> syn::Result<Self> {
+        let span = item_impl.span();
+        let (methods, rest): (Vec<_>, Vec<_>) =
+            item_impl
+                .items
+                .into_iter()
+                .partition_map(|item| match item {
+                    ImplItem::Method(method) => Either::Left(method),
+                    other => Either::Right(other),
+                });
+
+        let init_method = Self::get_annotated_method(span, &methods)?;
+        let init_method = if let Some(init_method) = init_method {
+            init_method
+        } else {
+            Self::get_only_method(span, &methods)?
+        };
+
+        let methods = strip_annotation_by_path(methods, Self::init_annotation_path())
+            .into_iter()
+            .map(ImplItem::Method);
+        let items = rest.into_iter().chain(methods).collect();
+
+        Ok(Self {
+            item_impl: ItemImpl { items, ..item_impl },
+            init_method,
+        })
+    }
+
+    fn get_annotated_method(
+        span: Span,
+        methods: &[ImplItemMethod],
+    ) -> syn::Result<Option<ImplItemMethod>> {
+        let annotated_methods = methods
+            .iter()
+            .flat_map(|method| {
+                match method
+                    .attrs
+                    .iter()
+                    .find(|attr| attr.path == Self::init_annotation_path())
+                {
+                    Some(_) => Some(method),
+                    _ => None,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        match annotated_methods.as_slice() {
+            [method] => Ok(Some((*method).clone())),
+            [] => Ok(None),
+            _ => Err(syn::Error::new(
+                span,
+                format!(
+                    "Found more than one method annotated with #[{}] in impl!",
+                    Self::INIT_ANNOTATION_STR
+                ),
+            )),
+        }
+    }
+
+    fn get_only_method(span: Span, methods: &[ImplItemMethod]) -> syn::Result<ImplItemMethod> {
+        match methods {
+            [method] => Ok((*method).clone()),
+            _ => Err(syn::Error::new(span, "Expected one method in impl!")),
+        }
+    }
+
+    fn init_annotation_path() -> Path {
+        parse_str(Self::INIT_ANNOTATION_STR).unwrap()
+    }
+}


### PR DESCRIPTION
Implements #17.

`#[inject_init]` can now be used to annotate which method `#[inject]` should call in its generated `Dependency` impl. If the annotation isn't present on any method, `#[inject]` ensures there is only one method in the impl block or an error is returned. If two `#[inject_init]` annotations are present, an error indicating that only one method should be specified is returned.