### PR TITLE
Implement `Resolver` for all `ResolveContainers`

### DIFF
--- a/teloc/src/lib.rs
+++ b/teloc/src/lib.rs
@@ -72,6 +72,7 @@ mod service_provider;
 pub use actix_support::DiActixHandler;
 
 pub use {
+    container::ResolveContainer,
     dependency::Dependency,
     resolver::Resolver,
     service_provider::ServiceProvider,


### PR DESCRIPTION
**WORK IN PROGRESS**
- [ ] Fix a compilation issue where DiActixHandler generic params are not inferred
- [ ] Update documentation

This PR changes how `Resolver` and `ResolveContainer` are used internally and by downstream projects, specifically how new container types are added. **tl;dr** `Resolver` is now generically implemented for all implementations of `ResolveContainer`

Prior to this PR, to fully implement a new container you needed to implement 3 traits: `Container`, `ResolveContainer`, and `Resolver`. `Container` is responsible for making an object addable to a `ServiceProvider`, `ResolveContainer` is responsible for extracting a value out of the container, and `Resolver` is responsible for providing an easy to use interface to devs to resolve the type they want in addition to some light type transformations (like returning a borrow from an owned object). Since `Resolver` is mostly a thin wrapper around `ResolveContainer`, mostly being used to extract the container type from inferred generic params, it makes sense to move the transformation piece into `ResolveContainer`. This both simplifies the implementation of `Resolver` but also makes it much easier to implement whole new containers.

