### PR TITLE
Dependency lifetimes resolved through ServiceProvider::parent are not preserved

### DIFF
--- a/teloc/src/dev.rs
+++ b/teloc/src/dev.rs
@@ -1,9 +1,6 @@
 //! The module for the advanced usage.
 
-pub use crate::{dependency::DependencyClone, get_dependencies::GetDependencies};
-
-pub mod container {
-    //! Things needs to define your own containers.
-
-    pub use crate::container::*;
-}
+pub use crate::container::*;
+pub use crate::dependency::DependencyClone;
+pub use crate::get_dependencies::GetDependencies;
+pub use crate::service_provider::SelectContainer;

--- a/teloc/src/lib.rs
+++ b/teloc/src/lib.rs
@@ -58,11 +58,12 @@
 
 #![deny(unsafe_code)]
 
+pub mod dev;
+
 #[cfg(feature = "actix-support")]
 mod actix_support;
 mod container;
 mod dependency;
-pub mod dev;
 mod get_dependencies;
 mod index;
 mod resolver;

--- a/teloc/tests/lifetimes.rs
+++ b/teloc/tests/lifetimes.rs
@@ -58,3 +58,105 @@ fn test_lifetimes() {
     assert_eq!(si1.u, si2.u);
     assert_eq!(i1.u, i2.u);
 }
+
+#[test]
+fn test_resolve_nested_fork() {
+    let provider = ServiceProvider::new().add_instance(10u8);
+    let forked_provider = provider.fork();
+    let double_forked_provider = forked_provider.fork();
+
+    let num: &u8 = double_forked_provider.resolve();
+    assert_eq!(num, &10u8);
+}
+
+#[test]
+fn test_forked_lifetime() {
+    let provider = ServiceProvider::new().add_instance(10u8);
+    let num: &u8 = provider.resolve();
+
+    let forked_num: &u8 = {
+        let provider = provider.fork();
+        provider.resolve()
+    };
+
+    assert_eq!(num, forked_num);
+}
+
+#[test]
+fn test_resolve_instance_with_greater_lifetime() {
+    let num = 10u8;
+
+    let resolved_num: &u8 = {
+        let provider = ServiceProvider::new().add_instance(&num);
+        provider.resolve()
+    };
+
+    assert_eq!(num, *resolved_num);
+}
+
+#[test]
+fn test_resolve_singleton_with_greater_lifetime() {
+    let provider = ServiceProvider::new().add_singleton::<Uuid>();
+    let uuid: &Uuid = provider.resolve();
+
+    let forked_uuid: &Uuid = {
+        let provider = provider.fork();
+        provider.resolve()
+    };
+
+    assert_eq!(uuid, forked_uuid);
+}
+
+#[test]
+fn test_resolve_transient_with_greater_lifetime() {
+    let provider = ServiceProvider::new().add_transient::<Uuid>();
+    let uuid: Uuid = provider.resolve();
+
+    let forked_uuid: Uuid = {
+        let provider = provider.fork();
+        provider.resolve()
+    };
+
+    assert_ne!(uuid, forked_uuid);
+}
+
+struct SingletonWithBorrowedDep<'a> {
+    dep: &'a i32,
+}
+
+#[inject]
+impl<'a> SingletonWithBorrowedDep<'a> {
+    pub fn new(dep: &'a i32) -> Self {
+        Self { dep }
+    }
+}
+
+#[test]
+fn test_resolve_singleton_deps_with_greater_lifetime() {
+    let provider = ServiceProvider::new()
+        .add_instance(10i32)
+        .add_singleton::<SingletonWithBorrowedDep>();
+    let singleton: &SingletonWithBorrowedDep = provider.resolve();
+
+    let forked_singleton: &SingletonWithBorrowedDep = {
+        let provider = provider.fork();
+        provider.resolve()
+    };
+
+    assert_eq!(singleton.dep, forked_singleton.dep);
+}
+
+#[test]
+fn test_resolve_transient_deps_with_greater_lifetime() {
+    let provider = ServiceProvider::new()
+        .add_instance(10i32)
+        .add_transient::<SingletonWithBorrowedDep>();
+    let singleton: SingletonWithBorrowedDep = provider.resolve();
+
+    let forked_singleton: SingletonWithBorrowedDep = {
+        let provider = provider.fork();
+        provider.resolve()
+    };
+
+    assert_eq!(singleton.dep, forked_singleton.dep);
+}


### PR DESCRIPTION
 Fixes #19 

The main changes in this PR include defining a new trait `SelectContainer`, which replaces `Selector` implemented for `ServiceProvider`. This has the benefit of removing 2 uses of `unreachable!()` and enables passing around 2 lifetimes, instead of 1. 

This implementation isn't ideal, GATs will dramatically reduce the amount of code and complexity here, but this is a good starting point until its implemented. I should be able to reuse some of the code introduced here. 