### PR TITLE
pub use EmptyServiceProvider

### DIFF
--- a/teloc/src/lib.rs
+++ b/teloc/src/lib.rs
@@ -74,7 +74,7 @@ pub use actix_support::DiActixHandler;
 pub use {
     dependency::Dependency,
     resolver::Resolver,
-    service_provider::ServiceProvider,
+    service_provider::{EmptyServiceProvider, ServiceProvider},
     teloc_macros::{inject, Dependency},
 };
 


### PR DESCRIPTION
this allows a user to actually follow the instructions under:
> Get type of instance of `ServiceProvider`

cause it requires the explicit use of EmptyServiceProvider as first type param in ServiceProvider