### PR TITLE
Export EmptyServiceProvider publicly

### DIFF
--- a/teloc/src/dev.rs
+++ b/teloc/src/dev.rs
@@ -1,6 +1,0 @@
-//! The module for the advanced usage.
-
-pub use crate::container::*;
-pub use crate::dependency::DependencyClone;
-pub use crate::get_dependencies::GetDependencies;
-pub use crate::service_provider::SelectContainer;

--- a/teloc/src/lib.rs
+++ b/teloc/src/lib.rs
@@ -58,8 +58,6 @@
 
 #![deny(unsafe_code)]
 
-pub mod dev;
-
 #[cfg(feature = "actix-support")]
 mod actix_support;
 mod container;
@@ -73,9 +71,11 @@ mod service_provider;
 pub use actix_support::DiActixHandler;
 
 pub use {
-    dependency::Dependency,
+    container::*,
+    dependency::{Dependency, DependencyClone},
+    get_dependencies::GetDependencies,
     resolver::Resolver,
-    service_provider::{EmptyServiceProvider, ServiceProvider},
+    service_provider::{EmptyServiceProvider, SelectContainer, ServiceProvider},
     teloc_macros::{inject, Dependency},
 };
 

--- a/teloc/src/service_provider.rs
+++ b/teloc/src/service_provider.rs
@@ -123,7 +123,6 @@ impl<Parent, Conts: HList> ServiceProvider<Parent, Conts> {
     ///
     /// ```
     /// use teloc::*;
-    /// use teloc::dev::TransientContainer;
     ///
     /// struct Service {
     ///     data: i32,
@@ -353,8 +352,7 @@ impl<Parent, Conts: HList> ServiceProvider<Parent, Conts> {
 /// Borrow containers from a ServiceProvider.
 ///
 /// ```
-/// # use teloc::{Dependency, Resolver, ServiceProvider};
-/// # use teloc::dev::*;
+/// # use teloc::*;
 /// let cont: &InstanceContainer<i32> =
 ///     ServiceProvider::new().add_instance(10i32).get();
 /// ```
@@ -363,7 +361,6 @@ impl<Parent, Conts: HList> ServiceProvider<Parent, Conts> {
 ///
 /// ```
 /// # use teloc::*;
-/// # use teloc::dev::*;
 /// let provider = ServiceProvider::new().add_instance(10i32);
 /// let invalid_singleton: &InstanceContainer<i32> = {
 ///     let provider = provider.fork();

--- a/teloc/tests/fully_qualified_type.rs
+++ b/teloc/tests/fully_qualified_type.rs
@@ -1,4 +1,3 @@
-use teloc::dev::container::{ConvertContainer, InstanceContainer, TransientContainer};
 use teloc::reexport::frunk::{HCons, HNil};
 use teloc::*;
 struct NumberServiceOptions(i32);

--- a/teloc/tests/fully_qualified_type.rs
+++ b/teloc/tests/fully_qualified_type.rs
@@ -1,0 +1,64 @@
+use teloc::dev::container::{ConvertContainer, InstanceContainer, TransientContainer};
+use teloc::reexport::frunk::{HCons, HNil};
+use teloc::*;
+struct NumberServiceOptions(i32);
+
+trait NumberService {
+    fn get_num(&self) -> i32;
+}
+
+struct ConstService {
+    number: i32,
+}
+impl NumberService for ConstService {
+    fn get_num(&self) -> i32 {
+        self.number
+    }
+}
+#[inject]
+impl ConstService {
+    fn new(options: &NumberServiceOptions) -> Self {
+        ConstService { number: options.0 }
+    }
+}
+impl From<Box<ConstService>> for Box<dyn NumberService> {
+    fn from(x: Box<ConstService>) -> Self {
+        x
+    }
+}
+
+#[derive(Dependency)]
+struct Controller {
+    number_service: Box<dyn NumberService>,
+}
+
+// This type was captured from diagnostic output
+type SP = ServiceProvider<
+    EmptyServiceProvider,
+    HCons<
+        InstanceContainer<NumberServiceOptions>,
+        HCons<
+            TransientContainer<Controller>,
+            HCons<
+                ConvertContainer<
+                    TransientContainer<Box<ConstService>>,
+                    Box<ConstService>,
+                    Box<dyn NumberService>,
+                >,
+                HNil,
+            >,
+        >,
+    >,
+>;
+
+#[test]
+fn test() {
+    let options = NumberServiceOptions(10);
+    let container: SP = ServiceProvider::new()
+        .add_transient_c::<Box<dyn NumberService>, Box<ConstService>>()
+        .add_transient::<Controller>()
+        .add_instance(options);
+    let controller: Controller = container.resolve();
+
+    assert_eq!(controller.number_service.get_num(), 10);
+}


### PR DESCRIPTION
Exporting EmptyServiceProvider allows external users to specify the fully qualified service provider type.

Fixes #29 